### PR TITLE
Update SDK versions and build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.android.application' version '7.2.2' apply false
-    id 'com.android.library' version '7.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.0' apply false
+    id 'com.android.application' version '8.9.2' apply false
+    id 'com.android.library' version '8.9.2' apply false
+    id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 05 10:09:56 CET 2023
+#Tue Feb 17 19:30:15 IRST 2026
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/sso/build.gradle
+++ b/sso/build.gradle
@@ -10,11 +10,11 @@ file("netbox.properties").withInputStream { netboxProperties.load(it) }
 
 android {
     namespace 'ir.net_box.sso'
-    compileSdk 28
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 28
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -40,15 +40,17 @@ android {
     }
     buildFeatures{
         viewBinding true
+        buildConfig true
     }
 }
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation "org.jetbrains.kotlin:kotlin-test:2.1.0"
 
-//    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'junit:junit:4.13.2'
 //    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
 //    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }


### PR DESCRIPTION
- Upgrade `compileSdk` and `targetSdk` to 33.
- Update Gradle wrapper to 8.12.1 and Android Gradle Plugin to 8.9.2.
- Upgrade Kotlin to 2.1.0 and update several AndroidX dependencies.
- Enable `buildConfig` in build features.
- Uncomment and add unit testing dependencies.